### PR TITLE
[Feat] #42 그리드 리스트 클릭시 상세보기모달 보이기

### DIFF
--- a/src/common/NavBar.jsx
+++ b/src/common/NavBar.jsx
@@ -9,7 +9,7 @@ function NavBar({ content, onClickHandler }) {
         <BiArrowBack style={{ width: '100%', height: '100%' }} />
       </ButtonWrapper>
       <NavTitle>{content}</NavTitle>
-      <ButtonWrapper>
+      <ButtonWrapper onClick={onClickHandler}>
         <BiX style={{ width: '100%', height: '100%' }} />
       </ButtonWrapper>
     </NavWrapper>

--- a/src/components/GridList.jsx
+++ b/src/components/GridList.jsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
-import { addViewQuantity } from '../modules/viewQuantity';
+import {
+  addViewQuantity,
+  setShowDetailView,
+  setStartIndex,
+} from '../modules/viewQuantity';
 
 export default function GridList() {
   const quantity = useSelector((state) => state.viewQuantity.quantity);
@@ -26,7 +30,15 @@ export default function GridList() {
   };
 
   handleScroll();
-  const imgClickHandler = (e) => {};
+  const imgClickHandler = (e) => {
+    const idx = e.target.alt;
+    dispatch(setStartIndex(idx));
+    dispatch(setShowDetailView());
+  };
+  console.log(
+    'startidx',
+    useSelector((state) => state.viewQuantity.startIdx),
+  );
   return (
     <Container>
       {showLists.map((list, idx) => (
@@ -49,4 +61,7 @@ const Img = styled.img`
   margin-top: 1px;
   width: 165px;
   height: 165px;
+  :hover {
+    cursor: pointer;
+  }
 `;

--- a/src/modules/viewQuantity.js
+++ b/src/modules/viewQuantity.js
@@ -1,10 +1,18 @@
 const ADD_VIEW_QUANTITY = 'viewQuantity/ADD_VIEW_QUANTITY';
 const INIT_VIEW_QUANTITY = 'viewQuantity/INIT_VIEW_QUANTITY';
+const SET_START_INDEX = 'viewQuantity/SET_START_INDEX';
+const SET_SHOW_DETAIL_VIEW = 'viewQuantity/SET_SHOW_DETAIL_VIEW';
 
 export const addViewQuantity = () => ({ type: ADD_VIEW_QUANTITY });
 export const initViewQuantity = () => ({ type: INIT_VIEW_QUANTITY });
+export const setStartIndex = (idx) => ({ type: SET_START_INDEX, idx });
+export const setShowDetailView = () => ({ type: SET_SHOW_DETAIL_VIEW });
 
-const initialState = { quantity: 29 };
+const initialState = {
+  quantity: 29,
+  startIdx: 0,
+  showDetailView: false,
+};
 
 export default function viewQuantity(state = initialState, action) {
   switch (action.type) {
@@ -18,6 +26,17 @@ export default function viewQuantity(state = initialState, action) {
       return {
         ...state,
         quantity: 30,
+      };
+
+    case SET_START_INDEX:
+      return {
+        ...state,
+        startIdx: action.idx,
+      };
+    case SET_SHOW_DETAIL_VIEW:
+      return {
+        ...state,
+        showDetailView: !state.showDetailView,
       };
     default:
       return state;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -7,15 +7,21 @@ import InfinityList from '../components/InfinityList';
 import SelectListBtn from '../components/SelectListBtn';
 import AddReviewBtn from '../components/main/AddReviewBtn';
 import ReviewDetail from './ReviewDetail';
+import { useDispatch, useSelector } from 'react-redux';
+import { setShowDetailView } from '../modules/viewQuantity';
 
 export default function Main() {
   const [showList, setShowList] = useState(true);
-  const [isReviewDetailVisible, setIsReviewDetailVisible] = useState(true);
+  // const [isReviewDetailVisible, setIsReviewDetailVisible] = useState(true);
+  const isReviewDetailVisible = useSelector(
+    (state) => state.viewQuantity.showDetailView,
+  );
+  const dispatch = useDispatch();
 
   const hideReviewDetailModal = () => {
-    setIsReviewDetailVisible(false);
+    dispatch(setShowDetailView());
   };
-
+  console.log('show?', isReviewDetailVisible);
   return (
     <Wrapper>
       {isReviewDetailVisible && (

--- a/src/pages/ReviewDetail.jsx
+++ b/src/pages/ReviewDetail.jsx
@@ -9,8 +9,8 @@ function ReviewDetail({ returnButtonHandler }) {
   const dispatch = useDispatch();
   const reviews = useSelector((state) => state.reviews);
   const quantity = useSelector((state) => state.viewQuantity.quantity);
-
-  const reviewsList = reviews.slice(0, quantity);
+  const startIdx = useSelector((state) => state.viewQuantity.startIdx);
+  const reviewsList = reviews.slice(startIdx, quantity);
   const handleScroll = () => {
     // if (quantity > lists.length) return;
     console.log('hii');


### PR DESCRIPTION
- 그리드 이미지 클릭시 전역상태로 리스트 시작 인덱스 재설정
- 그리드 이미지 클릭시 상세리스트 모달 보이도록 상태변경
- 상세보기 모달생성시 리스트는 전역상태인 시작인덱스부터 리스트 재생성

 Please enter the commit message for your changes. Lines starting